### PR TITLE
add missing dot for tsx file extension

### DIFF
--- a/packages/core/src/lib/executors/Node.ts
+++ b/packages/core/src/lib/executors/Node.ts
@@ -992,7 +992,7 @@ export default class Node extends Executor<NodeEvents, NodePlugins> {
         this._coverageFiles[filename] = true;
         return this.instrumentCode(code, filename);
       },
-      { extensions: ['.js', '.jsx', '.ts', 'tsx'] }
+      { extensions: ['.js', '.jsx', '.ts', '.tsx'] }
     );
   }
 


### PR DESCRIPTION
This missing dot results in .tsx file not being included in coverage reports.